### PR TITLE
Fix buffer wipe logic

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -65,7 +65,10 @@ export const wipe = functions.https.onCall(async (data, context) => {
         if (typeof buffer == "object") {
           const arr: { id: string }[] = Object.values(buffer);
           const index = arr.findIndex((v) => v.id === data.id);
-          return arr.splice(index + 1);
+          if (index >= 0) {
+            arr.splice(0, index + 1);
+          }
+          return arr;
         }
         throw new Error(
           `buffer not as expected ${typeof buffer} ${JSON.stringify(buffer)}`

--- a/plugin/main.ts
+++ b/plugin/main.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, no-shadow */
 import { App, Notice, Plugin, PluginSettingTab, Setting } from "obsidian";
 import {
   Auth,


### PR DESCRIPTION
## Summary
- correctly remove processed events from Firebase buffer
- disable `no-shadow` warning so enum compiles cleanly

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683fbef44a84832b88ba2819abb65740